### PR TITLE
Add numpy/1.21.1 module

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,4 +1,4 @@
-manifest.version = '2.2.6'
+manifest.version = '2.2.7'
 
 /*
 ** bbi-sci process profiles.
@@ -108,22 +108,22 @@ profiles {
       clusterOptions = '-l centos=7'
 
       withName: check_sample_sheet {
-        module = 'modules:modules-init:modules-gs:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7'
       }
 
       withName: trim_fastqs {
-        module = 'modules:modules-init:modules-gs:python/3.7.7:cutadapt/1.18:trim_galore/0.6.5'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7:cutadapt/1.18:trim_galore/0.6.5'
         beforeScript = 'PATH=/net/gs/vol1/home/bge/bin:$PATH'
         memory = '16 GB'
       }
 
       withName: gather_info {
-        module = 'modules:modules-init:modules-gs:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7'
         memory = '2 GB'
       }
 
       withName: process_hashes {
-        module = 'modules:modules-init:modules-gs:python/3.7.7:scipy/1.2.3'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7:scipy/1.2.3'
         memory = '16 GB'
       }
 
@@ -149,12 +149,12 @@ profiles {
       }
 
       withName: split_bam {
-        module = 'modules:modules-init:modules-gs:samtools/1.9:bamtools/20200731:bedtools/2.27.1:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:samtools/1.9:bamtools/20200731:bedtools/2.27.1:numpy/1.21.1:python/3.7.7'
         memory = '8 GB'
       }
 
       withName: remove_dups_assign_genes {
-        module = 'modules:modules-init:modules-gs:bedtools/2.27.1:python/3.7.7:samtools/1.9'
+        module = 'modules:modules-init:modules-gs:bedtools/2.27.1:numpy/1.21.1:python/3.7.7:samtools/1.9'
         memory = '4 GB'
       }
 
@@ -164,12 +164,12 @@ profiles {
       }
 
       withName: count_umis_by_sample {
-        module = 'modules:modules-init:modules-gs:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7'
         memory = '8 GB'
       }
 
       withName: make_matrix {
-        module = 'modules:modules-init:modules-gs:python/3.7.7:numpy/1.19.0:scipy/1.2.3'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7:scipy/1.2.3'
         memory = '16 GB'
       }
 
@@ -184,12 +184,12 @@ profiles {
       }
 
       withName: run_scrublet {
-        module = 'modules:modules-init:modules-gs:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7'
         memory = '32 GB'
       }
 
       withName: reformat_qc {
-        module = 'modules:modules-init:modules-gs:python/3.7.7:gcc/8.1.0:pcre2/10.35:hdf5/1.10.1:R/4.0.0'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7:gcc/8.1.0:pcre2/10.35:hdf5/1.10.1:R/4.0.0'
         memory = '16 GB'
       }
 


### PR DESCRIPTION
The rogue numpy used by the pipeline has been removed by GSIT. numpy/1.21.1 module is now required to be loaded to run the pipeline.