### PR TITLE
Add module six/1.15.0

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,4 +1,4 @@
-manifest.version = '2.2.7'
+manifest.version = '2.2.8'
 
 /*
 ** bbi-sci process profiles.
@@ -184,7 +184,7 @@ profiles {
       }
 
       withName: run_scrublet {
-        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:six/1.15.0:python/3.7.7'
         memory = '32 GB'
       }
 


### PR DESCRIPTION
run_scrublet process requires a module named "six" to be loaded to finish running scrublet.