### PR TITLE
Add matplotlib/3.4.2 to run scrublet

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,4 +1,4 @@
-manifest.version = '2.2.8'
+manifest.version = '2.2.9'
 
 /*
 ** bbi-sci process profiles.
@@ -184,7 +184,7 @@ profiles {
       }
 
       withName: run_scrublet {
-        module = 'modules:modules-init:modules-gs:numpy/1.21.1:six/1.15.0:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:six/1.15.0:matplotlib/3.4.2:python/3.7.7'
         memory = '32 GB'
       }
 


### PR DESCRIPTION
matplotlib has now been separated from the python package by gsit. It has to be loaded as its own independent module prior to python/3.7.7 for running the scrublet process.